### PR TITLE
CSS to enforce the UI theme's font choice

### DIFF
--- a/styles/project-viewer.less
+++ b/styles/project-viewer.less
@@ -133,6 +133,10 @@ project-viewer {
 			opacity: 0.5;
 		}
 	}
+
+	span.icon {
+		font-family: @font-family;
+	}
 }
 
 pv-create-modal,
@@ -153,6 +157,7 @@ pv-remove-quick-modal {
 
 		.btn{
 			width: 32%;
+			font-family: @font-family;
 
 			&:before{
 				float: left;


### PR DESCRIPTION
The package currently has issues with the Tool Bar package in that the sidebar items and modal buttons are styled with the name of the icon. In the case of the Devicons set, this gets caught by the `[class^="devicon-"], [class*=" devicon-"]` rule in the Tool Bar package, and the result (on Windows) is that the text gets rendered as Times New Roman. This PR simply adds two highly-specific rules to target `span.icon` and `.btn` and enforce the font family present in `ui-variables.less`.