### PR TITLE
addIcons() now pre-seeds changesToItem if the item has an icon

### DIFF
--- a/src/modal-update-component.js
+++ b/src/modal-update-component.js
@@ -65,6 +65,11 @@ function addIcons () {
         return;
     }
 
+    if (itemIcon) {
+        changesToItem.hasIcon = true;
+        changesToItem.icon = itemIcon;
+    }
+
     views.icons = document.createElement('div');
     views.icons.classList.add('inset-panel', 'padded');
 


### PR DESCRIPTION
So, I did some looking around, and in the process I solved the problem of icon persistence. The `addIcons()` function turned out to be a great place for the code to take the `const itemIcon` that had already been defined and use that to pre-seed the global `changesToItem`. It's a slightly unintuitive way of doing things, but it's a very small change.

This resolves #52.