### PR TITLE
Forcing all icons at font-size: 16px

### DIFF
--- a/styles/project-viewer.less
+++ b/styles/project-viewer.less
@@ -140,6 +140,7 @@ project-viewer {
 
 	span.icon::before {
 		font-size: 16px;
+		font-size: @component-icon-size;
 	}
 }
 

--- a/styles/project-viewer.less
+++ b/styles/project-viewer.less
@@ -137,6 +137,10 @@ project-viewer {
 	span.icon {
 		font-family: @font-family;
 	}
+
+	span.icon::before {
+		font-size: 16px;
+	}
 }
 
 pv-create-modal,


### PR DESCRIPTION
The Devicon glyphs have been displaying at the `@font-size` defined by `ui-variables.less` as opposed to the 16px of the Octicons. In order to standardize the sizes of the icons (and line up the item names), I have implemented a `project-viewer span.icon:before` rule to force all icons to `font-size: 16px`.