### PR TITLE
Typo fixing

### DIFF
--- a/src/modal-create-component.js
+++ b/src/modal-create-component.js
@@ -201,7 +201,7 @@ function sortIcons (evt) {
     iconListArry.forEach(
         (child) => {
             // Removen the icon prefix for filter purpouse
-            const iconString = child.innerHTML.substring(child.innerHTML.indexOf('-')+1, child.innerHTML.lenght);
+            const iconString = child.innerHTML.substring(child.innerHTML.indexOf('-')+1, child.innerHTML.length);
             if(iconString.indexOf(filterString) > -1){
                 child.style.display = 'inline-block';
             } else {

--- a/src/modal-update-component.js
+++ b/src/modal-update-component.js
@@ -156,7 +156,7 @@ function sortIcons (evt) {
     iconListArry.forEach(
         (child) => {
             // Removen the icon prefix for filter purpouse
-            const iconString = child.innerHTML.substring(child.innerHTML.indexOf('-')+1, child.innerHTML.lenght);
+            const iconString = child.innerHTML.substring(child.innerHTML.indexOf('-')+1, child.innerHTML.length);
             if(iconString.indexOf(filterString) > -1){
                 child.style.display = 'inline-block';
             } else {


### PR DESCRIPTION
#70 introduced some typos. `modal-create-component.js:204` and `modal-update-component.js:159` both have `child.innerHTML.lenght` instead of `child.innerHTML.length`.
