### PR TITLE
Added 'next or last project' feature

### DIFF
--- a/keymaps/project-viewer.json
+++ b/keymaps/project-viewer.json
@@ -2,6 +2,8 @@
   ".platform-darwin, .platform-win32, .platform-linux": {
       "ctrl-alt-cmd-v": "project-viewer:toggle-select-view",
       "ctrl-alt-cmd-b": "project-viewer:toggle-display",
-      "ctrl-alt-cmd-n": "project-viewer:toggle-focus"
+      "ctrl-alt-cmd-n": "project-viewer:toggle-focus",
+      "ctrl-alt-shift-right": "project-viewer:next-project",
+      "ctrl-alt-shift-left": "project-viewer:previous-project"
   }
 }

--- a/keymaps/project-viewer.json
+++ b/keymaps/project-viewer.json
@@ -1,9 +1,16 @@
 {
-  ".platform-darwin, .platform-win32, .platform-linux": {
-      "ctrl-alt-cmd-v": "project-viewer:toggle-select-view",
-      "ctrl-alt-cmd-b": "project-viewer:toggle-display",
-      "ctrl-alt-cmd-n": "project-viewer:toggle-focus",
+  ".platform-win32, .platform-linux": {
+      "ctrl-alt-v": "project-viewer:toggle-select-view",
+      "ctrl-alt-b": "project-viewer:toggle-display",
+      "ctrl-alt-n": "project-viewer:toggle-focus",
       "ctrl-alt-shift-right": "project-viewer:next-project",
       "ctrl-alt-shift-left": "project-viewer:previous-project"
+  },
+  ".platform-darwin": {
+      "cmd-alt-v": "project-viewer:toggle-select-view",
+      "cmd-alt-b": "project-viewer:toggle-display",
+      "cmd-alt-n": "project-viewer:toggle-focus",
+      "cmd-alt-shift-right": "project-viewer:next-project",
+      "cmd-alt-shift-left": "project-viewer:previous-project"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -78,13 +78,13 @@ function nextOrPreviousProject (index) {
         }
     }
 
-    if (!current) { console.error("Project Viewer: No project currently selected."); return; }
+    if (!current) {_utils.notification('error', 'Project Viewer: No project currently selected.'); return; }
 
     if (current === output.length - 1 && index === 1) {  target = output[0];  }
     else if (current === 0 && index === -1) {  target = output[output.length - 1];  }
     else {  target = output[current + index]; }
 
-    if (!target) { console.error("Project Viewer: No valid target."); return; }
+    if (!target) {_utils.notification('error', 'Project Viewer: No valid target.'); return; }
 
     const eventClick = new CustomEvent('click', { 'detail': false });
 

--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,53 @@ const _views = new WeakMap();
 
 let bypass = false;
 
+function nextOrPreviousProject (index) {
+    // Generate an array of projects by selecting children of 'project-viewer > ul[is="pv-list-tree"]'. For each 'li[is="pv-list-nested-item"]', expand it into its children.
+    const sidebar = document.getElementsByTagName('project-viewer')[0];
+    let list = sidebar.getElementsByTagName('ul')[0].children;
+
+    var output = [];
+
+    var expandProjects = function (element) {
+        if (element.getAttribute('is') === "pv-list-nested-item") {
+            let nestedList = element.getElementsByTagName('ul')[0].children;
+
+            for (var i = 0; i < nestedList.length; i++) {
+                expandProjects(nestedList[i]);
+            }
+        }
+        else if (element.getAttribute('is') === "pv-list-item") {
+            output.push(element);
+        }
+    };
+
+    for (var i = 0; i < list.length; i++) {
+        expandProjects(list[i]);
+    }
+
+    for (var i = 0; i < output.length; i++) {
+        var txt = txt + output[i].children[0].innerHTML + "\n";
+    }
+
+    // Identify the target project and simulate a click event.
+    var target;
+
+    for (var i = 0; i < output.length; i++) {
+        if (output[i].classList.contains("active")) {
+          var current = i;
+          break;
+        }
+    }
+
+    if (current === output.length - 1 && index === 1) {  target = output[0];  }
+    else if (current === 0 && index === -1) {  target = output[output.length - 1];  }
+    else {  target = output[current + index]; }
+
+    const eventClick = new CustomEvent('click', { 'detail': false });
+
+    target.dispatchEvent(eventClick);
+}
+
 function elevateToProject () {
     let paths = atom.project.getPaths();
 
@@ -536,7 +583,9 @@ const projectViewer = {
                 'project-viewer:file-delete-old': fileDeleteOld.bind(this),
                 'project-viewer:elevate-project': elevateToProject.bind(this),
                 'project-viewer:open-new-window': openProject.bind(true),
-                'project-viewer:open-same-window': openProject.bind(false)
+                'project-viewer:open-same-window': openProject.bind(false),
+                'project-viewer:next-project': nextOrPreviousProject.bind(this, 1),
+                'project-viewer:previous-project': nextOrPreviousProject.bind(this, -1)
             }
         ));
 

--- a/src/index.js
+++ b/src/index.js
@@ -78,13 +78,13 @@ function nextOrPreviousProject (index) {
         }
     }
 
-    if (!current) {_utils.notification('error', 'Project Viewer: No project currently selected.'); return; }
+    if (!current) {_utils.notification('error', 'No project currently selected.'); return; }
 
     if (current === output.length - 1 && index === 1) {  target = output[0];  }
     else if (current === 0 && index === -1) {  target = output[output.length - 1];  }
     else {  target = output[current + index]; }
 
-    if (!target) {_utils.notification('error', 'Project Viewer: No valid target.'); return; }
+    if (!target) {_utils.notification('error', 'No valid target.'); return; }
 
     const eventClick = new CustomEvent('click', { 'detail': false });
 

--- a/src/index.js
+++ b/src/index.js
@@ -78,13 +78,13 @@ function nextOrPreviousProject (index) {
         }
     }
 
-    if (!current) { console.log("Project Viewer Error: No project currently selected."); return; }
+    if (!current) { console.error("Project Viewer: No project currently selected."); return; }
 
     if (current === output.length - 1 && index === 1) {  target = output[0];  }
     else if (current === 0 && index === -1) {  target = output[output.length - 1];  }
     else {  target = output[current + index]; }
 
-    if (!target) { console.log("Project Viewer Error: No valid target."); return; }
+    if (!target) { console.error("Project Viewer: No valid target."); return; }
 
     const eventClick = new CustomEvent('click', { 'detail': false });
 

--- a/src/index.js
+++ b/src/index.js
@@ -78,9 +78,13 @@ function nextOrPreviousProject (index) {
         }
     }
 
+    if (!current) { console.log("Project Viewer Error: No project currently selected."); return; }
+
     if (current === output.length - 1 && index === 1) {  target = output[0];  }
     else if (current === 0 && index === -1) {  target = output[output.length - 1];  }
     else {  target = output[current + index]; }
+
+    if (!target) { console.log("Project Viewer Error: No valid target."); return; }
 
     const eventClick = new CustomEvent('click', { 'detail': false });
 


### PR DESCRIPTION
I decided to tackle #22. This PR adds a function that navigates to the next or previous project (and could easily be expanded to navigate _n_ spots over), bound to `ctrl-alt-shift-right` and `ctrl-alt-shift-left` by default. I also tweaked the keymap (it had a `cmd` key for Windows/Linux functions and a `ctrl` key for Mac).
