### PR TITLE
Multiple working sets implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ Settings | Type | Description | Default
 `panelPosition` | `String` | You can set the place of the viewer, to the most right position or to the most left position. | `Right`
 `alwaysOpenInNewWindow` | `Boolean` | If set to true, always open projects in a new window (default Atom's behavior), instead of opening in the same window. | `false`
 `hideHeader` | `Boolean` | Hide header (for more space). | `false`
-`githubToken` | `String` | Your personal and private GitHub token. This is useful if you want to save/backup your projects to a remote place (as a gist). *note*: keep in mind that this token should have only permissions to `rw` gists as well as that any package can access this token string. | `''`
+`githubAccessToken` | `String` | Your personal and private GitHub access token. This is useful if you want to save/backup your projects to a remote place (as a gist). *note*: keep in mind that this token should have only permissions to `rw` gists as well as that any package can access this token string. | `''`
+`gistId` | `String` | ID of the gist used as a backup storage. | `''`
+`setName` | `String` | Name of your working set, for example 'work' or 'home'. As each working set is backed up into a separate file in one gist, you can have multiple Client/Group/Project sets on different machines and have them all safely backed up on gist. | `default`
 `convertOldData` | `Boolean` | If you came from a version previous to <code>0.3.0</code>, you most probably have the old data in the atom folder. By default it will always check on startup for this data and if the new does not exist, it will convert to the new data schema. | `true`
 
 ## Features & Future Features

--- a/src/config.js
+++ b/src/config.js
@@ -39,17 +39,31 @@ const config = {
         default: false,
         order: 5
     },
-    'githubToken': {
-        description: 'Your personal and private GitHub token. This is useful if you want to save/backup your projects to a remote place (as a gist). *note*: keep in mind that this token should have only permissions to `rw` gists as well as that any package can access this token string.',
+    'githubAccessToken': {
+        title: 'GitHub Access Token',
+        description: 'Your personal and private GitHub access token. This is useful if you want to save/backup your projects to a remote place (as a gist). *note*: keep in mind that this token should have only permissions to `rw` gists as well as that any package can access this token string.',
         type: 'string',
         default: '',
         order: 6
+    },
+    'gistId': {
+        title: 'Gist ID',
+        description: 'ID of the gist used as a backup storage.',
+        type: 'string',
+        default: '',
+        order: 7
+    },
+    'setName': {
+        description: 'Name of your working set, for example \'work\' or \'home\'. As each working set is backed up into a separate file in gist, you can have multiple Client/Group/Project sets on different machines and have them all safely backed up on gist.',
+        type: 'string',
+        default: 'default',
+        order: 8
     },
     'convertOldData': {
         description: 'If you came from a version previous to <code>0.3.0</code>, you most probably have the old data in the atom folder. By default, it will always check on startup for this data and if the new does not exist, it will convert to the new data schema.',
         type: 'boolean',
         default: true,
-        order: 7
+        order: 9
     }
 };
 

--- a/src/github-web-worker.js
+++ b/src/github-web-worker.js
@@ -1,47 +1,38 @@
 const api = {
+  url: 'https://api.github.com/gists',
+  gistDescription: 'atom.io project-viewer backup files',
   token: undefined,
   gistId: undefined,
   setName: 'default',
   get gistFileName() {
     return `project-viewer-${this.setName}.json`;
   },
-  url: 'https://api.github.com/gists',
-  gistDescription: 'atom.io project-viewer backup files',
-  checkToken: function checkToken() {
-    const promise = new Promise((resolve, reject) => {
-
-      // check if github access token is configured
-      if (!this.token) {
-        reject({
-          type: 'warning',
-          message: 'No <strong>Github Access Token</strong> was provided, please check the configuration.',
-          options: {
-            icon: 'mark-github'
-          }
-        });
-        return;
+  connectionError: function connectionError(error) {
+    return {
+      type: 'error',
+      message: `Failed to connect to <strong>GitHub</strong> servers: ${error.message}`,
+      options: {
+        icon: 'mark-github'
       }
-      resolve();
-    });
-
-    return promise;
+    };
   },
-  checkGistId: function checkGistId() {
+  // helper function to check whether given configuration value is defined
+  checkConfig: function checkConfig(value, name) {
     const promise = new Promise((resolve, reject) => {
 
-      // check if gist id is configured
-      if (!this.gistId) {
-        reject({
-          type: 'warning',
-          message: 'No <strong>Gist ID</strong> was provided, please check the configuration.',
-          options: {
-            icon: 'mark-github'
-          }
-        });
+      // check if given value is defined
+      if (value) {
+        resolve();
         return;
       }
 
-      resolve();
+      reject({
+        type: 'warning',
+        message: `No <strong>${name}</strong> was provided, please check the configuration.`,
+        options: {
+          icon: 'mark-github'
+        }
+      });
     });
 
     return promise;
@@ -60,32 +51,33 @@ const api = {
       };
 
       fetch(url, parameters)
-        .then((response) => {
-          return response.json();
-        })
-        .then((data) => {
-          if (!data || !data.files || !data.files.hasOwnProperty(this.gistFileName)) {
-            // backup not found, either gist with given ID doesnt exist (user hasnt created the gist yet or it has been deleted) or user has no existing backup
-            reject({
-              type: 'warning',
-              message: `No backup found under gist ID [${this.gistId}] for set [${this.setName}]. Make sure that gist with given ID exists under your private gists and that you have an existing backup (call backup -> call import).`,
+        .then(this.toJson.bind(null, 200))
+        .then(data => {
+          if (data && data.files && data.files.hasOwnProperty(this.gistFileName)) {
+            // backup found, returning
+            resolve({
+              type: 'success',
+              message: 'Retrieved DB from <strong>GitHub</strong> successfully.',
+              db: JSON.parse(data.files[this.gistFileName].content),
               options: {
-                icon: 'mark-github',
-                dismissable: true
+                icon: 'mark-github'
               }
             });
             return;
           }
 
-          // backup found, returning
-          resolve({
-            type: 'success',
-            message: 'Retrieved DB from <strong>GitHub</strong> successfully.',
-            db: JSON.parse(data.files[this.gistFileName].content),
+          // backup not found, response status code was not 200 OK
+          // either gist with given ID doesnt exist (user hasnt created the gist yet or it has been deleted) or user has no existing backup
+          reject({
+            type: 'warning',
+            message: `No backup found under gist ID [${this.gistId}] for set [${this.setName}]. Make sure that gist with given ID exists under your private gists and that you have an existing backup (call backup -> call import).`,
             options: {
-              icon: 'mark-github'
+              icon: 'mark-github',
+              dismissable: true
             }
           });
+        }).catch(error => {
+          reject(this.connectionError(error));
         });
     });
 
@@ -93,131 +85,183 @@ const api = {
   },
   updateGist: function updateGist(value) {
     const promise = new Promise((resolve, reject) => {
+      let url = this.url + '/' + this.gistId;
 
-      // common headers
       let headers = new Headers();
       headers.append('Accept', 'application/vnd.github.v3+json');
       headers.append('Authorization', `token ${this.token}`);
 
-      if (this.gistId) {
-        // user provided gist id, check if gist exists (if yes update, otherwise reject)
-        let url = this.url + '/' + this.gistId;
+      let files = {};
+      files[this.gistFileName] = {
+        content: JSON.stringify(value)
+      };
 
-        let parameters = {
-          method: 'GET',
-          headers: headers,
-        };
+      let body = JSON.stringify({
+        description: this.gistDescription,
+        public: false,
+        files: files
+      });
 
-        fetch(url, parameters)
-          .then((response) => {
-            // if OK gist exists
-            if (response.ok) {
-              // update gist
-              let files = {};
-              files[this.gistFileName] = {
-                content: JSON.stringify(value)
-              };
+      parameters = {
+        method: 'PATCH',
+        headers: headers,
+        body: body
+      };
 
-              let body = JSON.stringify({
-                description: this.gistDescription,
-                public: false,
-                files: files
-              });
-
-              parameters = {
-                method: 'PATCH',
-                headers: headers,
-                body: body
-              };
-
-              fetch(url, parameters)
-                .then((response) => {
-                  if (response.ok) {
-                    // gist successfully updated
-                    resolve({
-                      type: 'success',
-                      message: 'Successfully backed up the DB.',
-                      options: {
-                        icon: 'mark-github'
-                      }
-                    });
-                    return;
-                  }
-
-                  reject({
-                    type: 'warning',
-                    message: 'Failed to update gist.',
-                    options: {
-                      icon: 'mark-github'
-                    }
-                  });
-                  return;
-                });
-            } else {
-              // non-OK response from GET on /gists/{gistId} -> gist with user provided gist id doesnt exist
-              reject({
-                type: 'warning',
-                message: `No gist found with ID [${this.gistId}]. Specify valid gist ID or specify empty gist ID and we will create a gist for you.`,
-                options: {
-                  icon: 'mark-github',
-                  dismissable: true
-                }
-              });
-              return;
-            }
-          });
-      } else {
-        // user didnt specify gist id, create gist for him and set it in config
-        let files = {};
-        files[this.gistFileName] = {
-          content: JSON.stringify(value)
-        };
-
-        let body = JSON.stringify({
-          description: this.gistDescription,
-          public: false,
-          files: files
-        });
-
-        let parameters = {
-          method: 'POST',
-          headers: headers,
-          body: body
-        };
-
-        fetch(this.url, parameters)
-          .then((response) => {
-            return response.json();
-          })
-          .then((data) => {
-            if (data && data.id) {
-              // gist successfully created
-              this.gistId = data.id;
-
-              resolve({
-                type: 'success',
-                message: `Successfully created gist ID [${data.id}] and backed up the DB.`,
-                options: {
-                  icon: 'mark-github'
-                },
-                gistId: data.id
-              });
-              return;
-            }
-
-            reject({
-              type: 'warning',
-              message: 'Failed to create gist.',
+      fetch(url, parameters)
+        .then((response) => {
+          if (response.status == 200) {
+            // gist successfully updated
+            resolve({
+              type: 'success',
+              message: 'Successfully backed up the DB.',
               options: {
                 icon: 'mark-github'
               }
             });
             return;
+          }
+
+          // failed to update gist, reponse status code was not 200 OK
+          reject({
+            type: 'warning',
+            message: 'Failed to update gist.',
+            options: {
+              icon: 'mark-github'
+            }
           });
+        }).catch(error => {
+          reject(this.connectionError(error));
+        });
+    });
+
+    return promise;
+  },
+  checkIfGistExists: function checkIfGistExists() {
+    const promise = new Promise((resolve, reject) => {
+      let url = this.url + '/' + this.gistId;
+
+      let headers = new Headers();
+      headers.append('Accept', 'application/vnd.github.v3+json');
+      headers.append('Authorization', `token ${this.token}`);
+
+      let parameters = {
+        method: 'GET',
+        headers: headers,
+      };
+
+      fetch(url, parameters)
+        .then(response => {
+          if (response.status == 200) {
+            // gist exists
+            resolve();
+            return;
+          }
+
+          // gist doesn't exist
+          reject({
+            type: 'warning',
+            message: `No gist found with ID [${this.gistId}]. Specify valid gist ID or specify empty gist ID and we will create a gist for you.`,
+            options: {
+              icon: 'mark-github',
+              dismissable: true
+            }
+          });
+        }).catch(error => {
+          reject(this.connectionError(error));
+        });
+    });
+
+    return promise;
+  },
+  createNewGist: function createNewGist(value) {
+    const promise = new Promise((resolve, reject) => {
+      let headers = new Headers();
+      headers.append('Accept', 'application/vnd.github.v3+json');
+      headers.append('Authorization', `token ${this.token}`);
+
+      let files = {};
+      files[this.gistFileName] = {
+        content: JSON.stringify(value)
+      };
+
+      let body = JSON.stringify({
+        description: this.gistDescription,
+        public: false,
+        files: files
+      });
+
+      let parameters = {
+        method: 'POST',
+        headers: headers,
+        body: body
+      };
+
+      fetch(this.url, parameters)
+        .then(this.toJson.bind(null, 201))
+        .then(data => {
+          if (data && data.id) {
+            // gist successfully created
+            this.gistId = data.id;
+
+            resolve({
+              type: 'success',
+              message: `Successfully created gist ID [${data.id}] and backed up the DB.`,
+              options: {
+                icon: 'mark-github'
+              },
+              gistId: data.id
+            });
+            return;
+          }
+
+          // failed to craete gist, response status code was not 201 Created
+          reject({
+            type: 'warning',
+            message: 'Failed to create gist.',
+            options: {
+              icon: 'mark-github'
+            }
+          });
+        }).catch(error => {
+          reject(this.connectionError(error));
+        });
+    });
+
+    return promise;
+  },
+  // orchestration function for update operation
+  updateOperation: function updateOperation(value) {
+    const promise = new Promise((resolve, reject) => {
+      if (this.gistId) {
+        // user provided gist id, check if gist exists (if yes update, otherwise reject)
+        this.checkIfGistExists()
+          .then(() => {
+            this.updateGist(value).then(resolve).catch(reject);
+          }).catch(reject);
+      } else {
+        // user didnt specify gist id, create gist for him and set it in config
+        this.createNewGist(value).then(resolve).catch(reject);
       }
     });
 
     return promise;
+  },
+  // orchestration function for fetch operation
+  fetchOperation: function fetchOperation() {
+    const promise = new Promise((resolve, reject) => {
+      this.getGist().then(resolve).catch(reject);
+    });
+
+    return promise;
+  },
+  // helper function to check whether the response status code equals the requiredStatusCode and return json promise if so
+  // we then check in Promise.then() if data exists (exists only if response respones status code matched)
+  toJson: function toJson(requiredStatusCode, response) {
+    if (response.status == requiredStatusCode) {
+      return response.json();
+    }
+    return Promise.resolve(undefined);
   }
 };
 
@@ -239,17 +283,17 @@ onmessage = function(e) {
   }
 
   if (e.data[0].action === 'fetch') {
-    Promise.all([api.checkToken(), api.checkGistId()])
+    Promise.all([api.checkConfig(api.token, 'Github Access Token'), api.checkConfig(api.gistId, 'Gist ID')])
       .then(() => {
-        api.getGist()
+        api.fetchOperation()
           .then(postMessage)
           .catch(postMessage);
       })
       .catch(postMessage);
   } else if (e.data[0].action === 'update') {
-    Promise.all([api.checkToken()])
+    Promise.all([api.checkConfig(api.token, 'Github Access Token')])
       .then(() => {
-        api.updateGist(e.data[0].value)
+        api.updateOperation(e.data[0].value)
           .then(postMessage)
           .catch(postMessage);
       })

--- a/src/github-web-worker.js
+++ b/src/github-web-worker.js
@@ -1,257 +1,260 @@
+const setNamePlaceholder = '{set-name}';
 const api = {
-    token: undefined,
-    gistId: undefined,
-    url: 'https://api.github.com/gists',
-    setPrivateGist: function setPrivateGist() {
-        const promise = new Promise((resolve, reject) => {
-            let headers = new Headers();
-            let parameters = {
-                method: 'POST',
-                headers: headers,
-                body: JSON.stringify({
-                    description: 'atom-project-viewer db file',
-                    public: false,
-                    files: {
-                        'project-viewer.json': {
-                            content: JSON.stringify({
-                                clients: [],
-                                groups: [],
-                                projects: []
-                            })
-                        }
-                    }
-                })
-            };
+  token: undefined,
+  gistId: undefined,
+  setName: 'default',
+  gistFilePattern: 'project-viewer-' + setNamePlaceholder + '.json',
+  get gistFileName() {
+    return this.gistFilePattern.replace(setNamePlaceholder, this.setName);
+  },
+  url: 'https://api.github.com/gists',
+  gistDescription: 'atom.io project-viewer backup files',
+  checkToken: function checkToken() {
+    const promise = new Promise((resolve, reject) => {
 
-            if (!this.token) {
-                reject({
-                    type: 'warning',
-                    message: 'no <strong>Github</strong>\'s token was provided, please check the configuration.',
-                    options: {
-                        icon: 'mark-github'
-                    }
-                });
-                return;
-            }
-
-            headers.append('Accept', 'application/vnd.github.v3+json');
-            headers.append('Authorization', 'token ' + this.token);
-
-            fetch(this.url, parameters)
-            .then(function(response) {
-                return response.json();
-            })
-            .then((data) => {
-                if (!data || !data.id) {
-                    reject({
-                        type: 'warning',
-                        message: 'no gist was created',
-                        options: {
-                            icon: 'mark-github'
-                        }
-                    });
-                    return;
-                }
-
-                this.gistId = data.id;
-
-                resolve({
-                    type: 'success',
-                    message: 'a new gist was created',
-                    options: {
-                        icon: 'mark-github'
-                    }
-                });
-            });
+      // check if github access token is configured
+      if (!this.token) {
+        reject({
+          type: 'warning',
+          message: 'No <strong>Github Access Token</strong> was provided, please check the configuration.',
+          options: {
+            icon: 'mark-github'
+          }
         });
-        return promise;
-    },
-    updatePrivateGist: function updatePrivateGist(value) {
-        const promise = new Promise((resolve, reject) => {
-            let body = JSON.stringify({
-                description: 'atom-project-viewer db file',
-                public: false,
-                files: {
-                    'project-viewer.json': {
-                        content: JSON.stringify(value)
-                    }
-                }
+        return;
+      }
+      resolve();
+    });
+
+    return promise;
+  },
+  checkGistId: function checkGistId() {
+    const promise = new Promise((resolve, reject) => {
+
+      // check if gist id is configured
+      if (!this.gistId) {
+        reject({
+          type: 'warning',
+          message: 'No <strong>Gist ID</strong> was provided, please check the configuration.',
+          options: {
+            icon: 'mark-github'
+          }
+        });
+        return;
+      }
+
+      resolve();
+    });
+
+    return promise;
+  },
+  getGist: function getGist() {
+    const promise = new Promise((resolve, reject) => {
+      let url = this.url + '/' + this.gistId;
+
+      let headers = new Headers();
+      headers.append('Accept', 'application/vnd.github.v3+json');
+      headers.append('Authorization', 'token ' + this.token);
+
+      let parameters = {
+        method: 'GET',
+        headers: headers
+      };
+
+      fetch(url, parameters)
+        .then((response) => {
+          return response.json();
+        })
+        .then((data) => {
+          if (!data || !data.files || !data.files.hasOwnProperty(this.gistFileName)) {
+            // backup not found, either gist with given ID doesnt exist (user hasnt created the gist yet or it has been deleted) or user has no existing backup
+            reject({
+              type: 'warning',
+              message: 'No backup found under gist ID [' + this.gistId + '] for set [' + this.setName + ']. Make sure that gist with given ID exists under your private gists and that you have an existing backup (call backup -> call import).',
+              options: {
+                icon: 'mark-github',
+                dismissable: true
+              }
             });
-            let headers = new Headers();
-            let url;
-            let parameters = {
+            return;
+          }
+
+          // backup found, returning
+          resolve({
+            type: 'success',
+            message: 'Retrieved DB from <strong>GitHub</strong> successfully.',
+            db: JSON.parse(data.files[this.gistFileName].content),
+            options: {
+              icon: 'mark-github'
+            }
+          });
+        });
+    });
+
+    return promise;
+  },
+  updateGist: function updateGist(value) {
+    const promise = new Promise((resolve, reject) => {
+
+      // common headers
+      let headers = new Headers();
+      headers.append('Accept', 'application/vnd.github.v3+json');
+      headers.append('Authorization', 'token ' + this.token);
+
+      if (this.gistId) {
+        // user provided gist id, check if gist exists (if yes update, otherwise reject)
+        let url = this.url + '/' + this.gistId;
+
+        let parameters = {
+          method: 'GET',
+          headers: headers,
+        };
+
+        fetch(url, parameters)
+          .then((response) => {
+            // if OK gist exists
+            if (response.ok) {
+              // update gist
+              let files = {};
+              files[this.gistFileName] = {
+                content: JSON.stringify(value)
+              };
+
+              let body = JSON.stringify({
+                description: 'this.gistDescription',
+                public: false,
+                files: files
+              });
+
+              parameters = {
                 method: 'PATCH',
                 headers: headers,
                 body: body
-            };
+              };
 
-            if (!this.token || !this.gistId) {
-                reject({
-                    type: 'warning',
-                    message: 'no token or gist id',
-                    options: {
+              fetch(url, parameters)
+                .then((response) => {
+                  if (response.ok) {
+                    // gist successfully updated
+                    resolve({
+                      type: 'success',
+                      message: 'Successfully backed up the DB.',
+                      options: {
                         icon: 'mark-github'
-                    }
-                });
-                return;
-            }
-
-            headers.append('Accept', 'application/vnd.github.v3+json');
-            headers.append('Authorization', 'token ' + this.token);
-
-            url = this.url + '/' + this.gistId;
-
-            fetch(url, parameters)
-            .then(function(response) {
-                return response.json();
-            })
-            .then((data) => {
-                if (!data || !data.id) {
-                    reject({
-                        type: 'info',
-                        message: 'no gist found',
-                        options: {
-                            icon: 'mark-github'
-                        }
+                      }
                     });
                     return;
-                }
+                  }
 
-                this.gistId = data.id;
-
-                resolve({
-                    type: 'success',
-                    message: 'Successfully backedup the DB',
-                    options: {
-                        icon: 'mark-github'
-                    }
-                });
-            });
-        });
-        return promise;
-    },
-    getPrivateGist: function getPrivateGist() {
-        const promise = new Promise((resolve, reject) => {
-            let headers = new Headers();
-            let url;
-            let parameters = {
-                method: 'GET',
-                headers: headers
-            };
-
-            if (!this.token || !this.gistId) {
-                reject('no token or gist id');
-                return;
-            }
-
-            url = this.url + '/' + this.gistId;
-
-            headers.append('Accept', 'application/vnd.github.v3+json');
-            headers.append('Authorization', 'token ' + this.token);
-
-            fetch(url, parameters)
-            .then(function(response) {
-                return response.json();
-            })
-            .then((data) => {
-                if (!data || !data.files || !data.files.hasOwnProperty('project-viewer.json')) {
-                    reject({
-                        type: 'warning',
-                        message: 'no gist found with id ' + this.gistId,
-                        options: {
-                            icon: 'mark-github'
-                        }
-                    });
-                    return;
-                }
-
-                resolve({
-                    type: 'success',
-                    message: 'Retrieved DB from <strong>GitHub</strong> successfully',
-                    db: JSON.parse(data.files['project-viewer.json'].content),
-                    options: {
-                        icon: 'mark-github'
-                    }
-                });
-            });
-        });
-        return promise;
-    },
-    checkForGist: function checkForGist() {
-        const promise = new Promise((resolve, reject) => {
-
-            let headers = new Headers();
-
-            if (!this.token) {
-                reject({
+                  reject({
                     type: 'warning',
-                    message: 'no <strong>Github</strong>\'s token was provided, please check the configuration.',
+                    message: 'Failed to update gist.',
                     options: {
-                        icon: 'mark-github'
+                      icon: 'mark-github'
                     }
+                  });
+                  return;
                 });
-                return;
+            } else {
+              // non-OK response from GET on /gists/{gistId} -> gist with user provided gist id doesnt exist
+              reject({
+                type: 'warning',
+                message: 'No gist found with ID [' + this.gistId + ']. Specify valid gist ID or specify empty gist ID and we will create a gist for you.',
+                options: {
+                  icon: 'mark-github',
+                  dismissable: true
+                }
+              });
+              return;
+            }
+          });
+      } else {
+        // user didnt specify gist id, create gist for him and set it in config
+        let files = {};
+        files[this.gistFileName] = {
+          content: JSON.stringify(value)
+        };
+
+        let body = JSON.stringify({
+          description: 'this.gistDescription',
+          public: false,
+          files: files
+        });
+
+        let parameters = {
+          method: 'POST',
+          headers: headers,
+          body: body
+        };
+
+        fetch(this.url, parameters)
+          .then((response) => {
+            return response.json();
+          })
+          .then((data) => {
+            if (data && data.id) {
+              // gist successfully created
+              this.gistId = data.id;
+
+              resolve({
+                type: 'success',
+                message: 'Successfully created gist ID [' + data.id + '] and backed up the DB.',
+                options: {
+                  icon: 'mark-github'
+                },
+                gistId: data.id
+              });
+              return;
             }
 
-            headers.append('Accept', 'application/vnd.github.v3+json');
-            headers.append('Authorization', 'token ' + this.token);
-
-            let parameters = {
-                method: 'GET',
-                headers: headers
-            };
-
-            fetch(this.url, parameters)
-            .then(function(response) {
-                return response.json();
-            })
-            .then((data) => {
-                if (!data || data.length === 0) {
-                    this.setPrivateGist().then(resolve).catch(reject);
-                } else {
-                    let hasGist = data.some((gist) => {
-                        let validation = gist.files.hasOwnProperty('project-viewer.json');
-                        if (validation) {
-                            this.gistId = gist.id;
-                        }
-                        return validation;
-                    });
-
-                    if (hasGist) {
-                        this.getPrivateGist().then(resolve).catch(reject);
-                    } else {
-                        this.setPrivateGist().then(resolve).catch(reject);
-                    }
-                }
+            reject({
+              type: 'warning',
+              message: 'Failed to create gist.',
+              options: {
+                icon: 'mark-github'
+              }
             });
-        });
-        return promise;
-    }
+            return;
+          });
+      }
+    });
+
+    return promise;
+  }
 };
 
 onmessage = function(e) {
-    if (!e.data || e.data.length === 0) {
-        return;
-    }
+  if (!e.data || e.data.length === 0) {
+    return;
+  }
 
-    if (e.data[0].hasOwnProperty('token')) {
-        api.token = e.data[0].token;
-    }
+  if (e.data[0].hasOwnProperty('token')) {
+    api.token = e.data[0].token;
+  }
 
-    if (e.data[0].action === 'fetch') {
-        api.checkForGist()
-        .then(postMessage)
-        .catch(postMessage);
-    }
-    else if (e.data[0].action === 'update') {
-        api.checkForGist()
-        .then(() => {
-            api.updatePrivateGist(e.data[0].value)
-            .then(postMessage)
-            .catch(postMessage);
-        })
-        .catch(postMessage);
-    }
+  if (e.data[0].hasOwnProperty('gistId')) {
+    api.gistId = e.data[0].gistId;
+  }
 
+  if (e.data[0].hasOwnProperty('setName')) {
+    api.setName = e.data[0].setName;
+  }
 
+  if (e.data[0].action === 'fetch') {
+    Promise.all([api.checkToken(), api.checkGistId()])
+      .then(() => {
+        api.getGist()
+          .then(postMessage)
+          .catch(postMessage);
+      })
+      .catch(postMessage);
+  } else if (e.data[0].action === 'update') {
+    Promise.all([api.checkToken()])
+      .then(() => {
+        api.updateGist(e.data[0].value)
+          .then(postMessage)
+          .catch(postMessage);
+      })
+      .catch(postMessage);
+  }
 }

--- a/src/github-web-worker.js
+++ b/src/github-web-worker.js
@@ -1,11 +1,9 @@
-const setNamePlaceholder = '{set-name}';
 const api = {
   token: undefined,
   gistId: undefined,
   setName: 'default',
-  gistFilePattern: 'project-viewer-' + setNamePlaceholder + '.json',
   get gistFileName() {
-    return this.gistFilePattern.replace(setNamePlaceholder, this.setName);
+    return `project-viewer-${this.setName}.json`;
   },
   url: 'https://api.github.com/gists',
   gistDescription: 'atom.io project-viewer backup files',
@@ -54,7 +52,7 @@ const api = {
 
       let headers = new Headers();
       headers.append('Accept', 'application/vnd.github.v3+json');
-      headers.append('Authorization', 'token ' + this.token);
+      headers.append('Authorization', `token ${this.token}`);
 
       let parameters = {
         method: 'GET',
@@ -70,7 +68,7 @@ const api = {
             // backup not found, either gist with given ID doesnt exist (user hasnt created the gist yet or it has been deleted) or user has no existing backup
             reject({
               type: 'warning',
-              message: 'No backup found under gist ID [' + this.gistId + '] for set [' + this.setName + ']. Make sure that gist with given ID exists under your private gists and that you have an existing backup (call backup -> call import).',
+              message: `No backup found under gist ID [${this.gistId}] for set [${this.setName}]. Make sure that gist with given ID exists under your private gists and that you have an existing backup (call backup -> call import).`,
               options: {
                 icon: 'mark-github',
                 dismissable: true
@@ -99,7 +97,7 @@ const api = {
       // common headers
       let headers = new Headers();
       headers.append('Accept', 'application/vnd.github.v3+json');
-      headers.append('Authorization', 'token ' + this.token);
+      headers.append('Authorization', `token ${this.token}`);
 
       if (this.gistId) {
         // user provided gist id, check if gist exists (if yes update, otherwise reject)
@@ -159,7 +157,7 @@ const api = {
               // non-OK response from GET on /gists/{gistId} -> gist with user provided gist id doesnt exist
               reject({
                 type: 'warning',
-                message: 'No gist found with ID [' + this.gistId + ']. Specify valid gist ID or specify empty gist ID and we will create a gist for you.',
+                message: `No gist found with ID [${this.gistId}]. Specify valid gist ID or specify empty gist ID and we will create a gist for you.`,
                 options: {
                   icon: 'mark-github',
                   dismissable: true
@@ -198,7 +196,7 @@ const api = {
 
               resolve({
                 type: 'success',
-                message: 'Successfully created gist ID [' + data.id + '] and backed up the DB.',
+                message: `Successfully created gist ID [${data.id}] and backed up the DB.`,
                 options: {
                   icon: 'mark-github'
                 },

--- a/src/github-web-worker.js
+++ b/src/github-web-worker.js
@@ -121,7 +121,7 @@ const api = {
               };
 
               let body = JSON.stringify({
-                description: 'this.gistDescription',
+                description: this.gistDescription,
                 public: false,
                 files: files
               });
@@ -176,7 +176,7 @@ const api = {
         };
 
         let body = JSON.stringify({
-          description: 'this.gistDescription',
+          description: this.gistDescription,
           public: false,
           files: files
         });

--- a/src/index.js
+++ b/src/index.js
@@ -331,6 +331,10 @@ function githubWorkerOnMessage(event) {
         updateProjectViewer.call(this);
     }
 
+    if (event.data.gistId) {
+      atom.config.set(_utility.getConfig('gistId'), event.data.gistId);
+    }
+
     _utils.notification(event.data.type, event.data.message, event.data.options);
 }
 
@@ -338,7 +342,9 @@ function fileBackup () {
     githubWorker.postMessage([
         {
             action: 'update',
-            token: atom.config.get(_utility.getConfig('githubToken')),
+            token: atom.config.get(_utility.getConfig('githubAccessToken')),
+            gistId: atom.config.get(_utility.getConfig('gistId')),
+            setName: atom.config.get(_utility.getConfig('setName')),
             value: _utility.getDB().getStorage()
         }
     ]);
@@ -348,7 +354,9 @@ function fileImport () {
     githubWorker.postMessage([
         {
             action: 'fetch',
-            token: atom.config.get(_utility.getConfig('githubToken'))
+            token: atom.config.get(_utility.getConfig('githubAccessToken')),
+            gistId: atom.config.get(_utility.getConfig('gistId')),
+            setName: atom.config.get(_utility.getConfig('setName'))
         }
     ]);
 }


### PR DESCRIPTION
# PULL REQUEST
I did an overhaul of your github-web-worker.js, which is now a bit more intelligent and can backup multiple sets of Client/Group/Project data (for example home or work, or work1, work2 etc.). The code is pretty simple, well formatted and commented where I deemed fit, but mostly its pretty self-explanatory.

There are 3 changes in configuration parameters:

1. **renamed**: Github Token was renamed to GitHub Access Token to convey its purpose more clearly
2. **added**: Gist ID - backups will be stored under this gist
3. **added**: Set Name - name of the working set

Required parameter is still only the **GitHub Access Token**. **Gist ID** can be specified, but if it isn't, a new gist is created and its ID is added into package configuration. **Set Name** can be specified, but if it isn't, value of _default_ is used.

This change also solves a rather unpleasant case which went like this:
1. user creates Client/Group/Project structure with this great package and is satisfied with the results
2. user clicks on 'backup my setup'
3. **empty** set is created in gist
4. user **imports** his setup
5. user's local setup is gone because it was overwritten with empty setup from gist
6. user is unhappy :(

Now working sets are backed up into gist in one call (no empty sets are created midway).

Resulting backup files are stored by pattern _project-viewer-_**{working_set}**_.json_, eg. the default backup file would be named _project-viewer-default.json_

## Reason
I was frustrated that I couldn't backup my project-viewer setups at work and also my personal space at home, prior to these changes they would overwrite each other (as the backup file was always named _project-viewer.json_).

I hope we get this in,
Cheers!