### PR TITLE
Add - Select-view: fuzzy searching and fix second line class name

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -47,6 +47,16 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "lneveu",
+      "name": "Loann Neveu",
+      "avatar_url": "https://avatars.githubusercontent.com/u/10619585?v=3",
+      "profile": "https://github.com/lneveu",
+      "contributions": [
+        "code",
+        "bug"
+      ]
     }
   ]
 }

--- a/src/select-view.js
+++ b/src/select-view.js
@@ -146,10 +146,9 @@ class PVSelectListView extends SelectListView {
             return list;
         }
 
+        query = query.toLowerCase();
         return list.filter(
-            (project) => {
-                return project.projectName.includes(query);
-            }
+            (project) => project.projectName.toLowerCase().indexOf(query) !== -1
         );
     }
 
@@ -184,7 +183,7 @@ class PVSelectListView extends SelectListView {
                     });
                 });
                 this.div({
-                    class: 'primary-secondary no-icon'
+                    class: 'secondary-line no-icon'
                 }, () => {
                     let projectLine = '';
                     if (item.clientName) {


### PR DESCRIPTION
# PULL REQUEST
Hi,

I made a little changes about select-view to enable fuzzy searching and fix 'secondary-line' class name according to the right naming and so works with all themes (with Seti-UI, projet/client/group names was on the same line).

(relative to #89)