### PR TITLE
Refacto - Select-view: use native functionnalities of atom-space-pen-views plugin

### DIFF
--- a/src/select-view.js
+++ b/src/select-view.js
@@ -15,6 +15,20 @@ class PVSelectListView extends SelectListView {
 
     initialize () {
         this.disposables = new CompositeDisposable();
+        this.disposables.add(
+            atom.commands.add(
+                'atom-workspace', {
+                    'core:move-up': this.selectPreviousItemView.bind(this),
+                    'core:move-down': this.selectNextItemView.bind(this),
+                    'core:confirm': this.confirmSelection.bind(this),
+                    'core:cancel': this.cancelSelection.bind(this)
+                }
+            )
+        );
+        // let the atom-space-pen-views plugin manage the update and the filtering (fuzzy search) of the list with the native 'populateList' function
+        this.disposables.add(
+            this.filterEditorView.getModel().getBuffer().onDidChange(this.populateList.bind(this))
+        );
         this.setLoading('Loading projects...');
     }
 
@@ -69,21 +83,6 @@ class PVSelectListView extends SelectListView {
                 item: this
             });
         }
-        this.disposables.add(
-            atom.commands.add(
-                'atom-workspace', {
-                    'core:move-up': this.selectPreviousItemView.bind(this),
-                    'core:move-down': this.selectNextItemView.bind(this),
-                    'core:confirm': this.confirmSelection.bind(this),
-                    'core:cancel': this.cancelSelection.bind(this)
-                }
-            )
-        );
-
-        // let the atom-space-pen-views plugin manage the update and the filtering (fuzzy search) of the list with the native 'populateList' function
-        this.disposables.add(
-            this.filterEditorView.getModel().getBuffer().onDidChange(this.populateList.bind(this))
-        );
         this.storeFocusedElement();
         this.panel.show();
         if (this.items.length > 0) {
@@ -93,7 +92,6 @@ class PVSelectListView extends SelectListView {
     }
 
     hide () {
-        this.disposables.dispose();
         if (this.panel) {
             this.list.empty();
             this.panel.hide();


### PR DESCRIPTION
# PULL REQUEST

According to your comment on this issue ( #89 ), I've refacto the select-view in order to use native functionnalities of the atom-space-pen-views plugin instead of duplicate them.
Now, the list of projects is updated and filtered by the plugin. It also enable fuzzy searching that is natively included. I did some other minor changes:

**Fix/Changes:**
- When no projects are found, the "empty message" displays; 'Couldn\'t find any projects'
- The list is updated each time a key is pressed (onDidChange instead of onDidStopChanging)

Are you ok with these changes? Please let me know :)
Also, I let you check and tell me if you find any anomalies!
