### PR TITLE
Add keepWindowSize option.

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -158,6 +158,15 @@
         "bug",
         "code"
       ]
+    },
+    {
+      "login": "audrummer15",
+      "name": "Adam Brown",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/1392689?v=4",
+      "profile": "https://github.com/audrummer15",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/src/config.js
+++ b/src/config.js
@@ -65,6 +65,13 @@ const config = {
     default: false,
     order: 7
   },
+  'keepWindowSize': {
+    title: 'Keep Window Size',
+    description: 'When changing projects, if set to `true`, the window size will not change.',
+    type: 'boolean',
+    default: false,
+    order: 7
+  },
   'openNewWindow': {
     title: 'Open in a new window',
     description: 'Always open items in a new window.',

--- a/src/project-view.js
+++ b/src/project-view.js
@@ -316,6 +316,10 @@ const openOnWorkspace = function _openOnWorkspace (reverseOption) {
       if (atom.config.get('project-viewer.keepContext')) {
         state.workspace.paneContainers.center = {};
       }
+      if (atom.config.get('project-viewer.keepWindowSize')) {
+        state.windowDimensions = atom.getWindowDimensions();
+        state.fullScreen = atom.isFullScreen();
+      }
 
       atom.deserialize(state);
       // atom.restoreStateIntoThisEnvironment(state);


### PR DESCRIPTION
# Pull Request
This pull requests adds an option to maintain window size between projects. 

## Reason
Referencing Issue #171. 
While the "remembered" window state of a project is sometimes nice, at other times it can be a hassle. This will allow the user to choose which works best for them.
